### PR TITLE
Limit number of processes required to complete Xsteps

### DIFF
--- a/bin/caveman.pl
+++ b/bin/caveman.pl
@@ -135,6 +135,7 @@ sub setup {
 					'sa|species-assembly=s' => \$opts{'species-assembly'},
 					'p|process=s' => \$opts{'process'},
 					'i|index=i' => \$opts{'index'},
+					'l|limit=i' => \$opts{'limit'},
   ) or pod2usage(2);
 
   pod2usage(-message => PCAP::license, -verbose => 2) if(defined $opts{'h'});
@@ -166,6 +167,7 @@ sub setup {
 
   delete $opts{'process'} unless(defined $opts{'process'});
   delete $opts{'index'} unless(defined $opts{'index'});
+  delete $opts{'limit'} unless(defined $opts{'limit'});
 
 	$opts{'splitList'} = File::Spec->catfile($opts{'outdir'},"splitList");
 	#vcf concat subs & snps
@@ -178,12 +180,16 @@ sub setup {
     PCAP::Cli::valid_process('process', $opts{'process'}, \@VALID_PROCESS);
     if(exists $opts{'index'}) {
       my $max = $index_max{$opts{'process'}};
-      my $max_idx=0;
       if($max==-1){
-      	$max_idx = Sanger::CGP::Caveman::Implement::valid_index(\%opts);
+        if(exists $options->{'limit'}) {
+          $max = $options->{'limit'}
+        }
+        else {
+      	  $max = Sanger::CGP::Caveman::Implement::valid_index(\%opts);
+      	}
       }
 
-      die "ERROR: based on reference and exclude option index must be between 1 and $max_idx\n" if($opts{'index'} < 1 || $opts{'index'} > $max);
+      die "ERROR: based on reference and exclude option index must be between 1 and $max\n" if($opts{'index'} < 1 || $opts{'index'} > $max);
       PCAP::Cli::opt_requires_opts('index', \%opts, ['process']);
 
       die "No max has been defined for this process type\n" if($max == 0);
@@ -239,6 +245,7 @@ caveman.pl [options]
    Optional parameters:
     -normal-contamination  -k   Normal contamination value (default 0.1)
     -threads               -t   Number of threads allowed on this machine (default 1)
+    -limit                 -l   Limit the number of jobs required for m/estep (default undef)
 
    Targeted processing (further detail under OPTIONS):
     -process   -p   Only process this step then exit, optionally set -index

--- a/t/cavemanImplement.t
+++ b/t/cavemanImplement.t
@@ -38,8 +38,28 @@ subtest 'Initialisation checks' => sub {
 };
 
 subtest 'Line count checks' => sub {
-	is($LINES_PER_FQ,Sanger::CGP::Caveman::Implement::file_line_count($good_fq),'Line count correct');
-	isnt($LINES_PER_FQ, Sanger::CGP::Caveman::Implement::file_line_count($bad_fq),'Line count correct (2)');
+	is(Sanger::CGP::Caveman::Implement::file_line_count($good_fq),$LINES_PER_FQ,'Line count correct');
+	isnt(Sanger::CGP::Caveman::Implement::file_line_count($bad_fq),$LINES_PER_FQ,'Line count correct (2)');
+};
+
+subtest 'Indicies limits' => sub {
+  my $options = {'splitList' => $good_fq};
+  my @indicies = Sanger::CGP::Caveman::Implement::limited_xstep_indicies($options, 1);
+  is(scalar @indicies, 1, 'No limit, single value');
+  is($indicies[0], 1, 'No limit, single value=1');
+  $options->{'limit'} = 4;
+  @indicies = Sanger::CGP::Caveman::Implement::limited_xstep_indicies($options, 1);
+  is(scalar @indicies, 1, 'Limit matches max jobs, single value');
+  is($indicies[0], 1, 'Limit matches max jobs, single value=1');
+  $options->{'limit'} = 2;
+  @indicies = Sanger::CGP::Caveman::Implement::limited_xstep_indicies($options, 1);
+  is(scalar @indicies, 2, 'Limit = max jobs/2, 2 values (index_in=1)');
+  is($indicies[0], 1, 'Limit = max jobs/2, value[0]=1 (index_in=1)');
+  is($indicies[1], 3, 'Limit = max jobs/2, value[1]=3 (index_in=1)');
+  @indicies = Sanger::CGP::Caveman::Implement::limited_xstep_indicies($options, 2);
+  is(scalar @indicies, 2, 'Limit = max jobs/2, 2 values (index_in=2)');
+  is($indicies[0], 2, 'Limit = max jobs/2, value[0]=2 (index_in=2)');
+  is($indicies[1], 4, 'Limit = max jobs/2, value[1]=4 (index_in=2)');
 };
 
 done_testing();


### PR DESCRIPTION
Hi @drjsanger, I've added an additional command line option `-l` which should provide the ability for the Implementation code to run in a restricted number of jobs with little modification to how it's handled elsewhere.  I've also added a test for this function to ensure it's getting it correct, feel free to expand it:

```
$ prove -v -I lib t/cavemanImplement.t
...
    ok 1 - No limit, single value
    ok 2 - No limit, single value=1
    ok 3 - Limit matches max jobs, single value
    ok 4 - Limit matches max jobs, single value=1
    ok 5 - Limit = max jobs/2, 2 values (index_in=1)
    ok 6 - Limit = max jobs/2, value[0]=1 (index_in=1)
    ok 7 - Limit = max jobs/2, value[1]=3 (index_in=1)
    ok 8 - Limit = max jobs/2, 2 values (index_in=2)
    ok 9 - Limit = max jobs/2, value[0]=2 (index_in=2)
    ok 10 - Limit = max jobs/2, value[1]=4 (index_in=2)
    1..10
ok 3 - Indicies limits
...
```

In the SeqWare workflow you just need to ensure that the `-l` option is declared (at present only m/estep will interpret it).
