### PR TITLE
WIP: Hotfix/1.17.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## 1.17.1
+
+* Updated Dockerfile to use PCAP-core 5.4.0 - samtools/htslib 1.11
+
 ## 1.17.0
 
 * Updated Dockerfile to use PCAP-core 5.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  quay.io/wtsicgp/pcap-core:5.2.2 as builder
+FROM  quay.io/wtsicgp/pcap-core:5.4.0 as builder
 
 USER  root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  quay.io/wtsicgp/pcap-core:5.4.1 as builder
+FROM  quay.io/wtsicgp/pcap-core:5.4.2 as builder
 
 USER  root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ FROM ubuntu:20.04
 
 LABEL maintainer="cgphelp@sanger.ac.uk" \
       uk.ac.sanger.cgp="Cancer, Ageing and Somatic Mutation, Wellcome Trust Sanger Institute" \
-      version="1.17.0" \
+      version="1.17.1" \
       description="cgpCaVEManWrapper docker"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  quay.io/wtsicgp/pcap-core:5.4.0 as builder
+FROM  quay.io/wtsicgp/pcap-core:5.4.1 as builder
 
 USER  root
 

--- a/lib/Sanger/CGP/Caveman.pm
+++ b/lib/Sanger/CGP/Caveman.pm
@@ -1,7 +1,7 @@
 package Sanger::CGP::Caveman;
 
 ##########LICENCE##########
-#  Copyright (c) 2014-2019 Genome Research Ltd.
+#  Copyright (c) 2014-2020 Genome Research Ltd.
 #
 #  Author: CASM/Cancer IT <cgphelp@sanger.ac.uk>
 #
@@ -26,6 +26,6 @@ package Sanger::CGP::Caveman;
 use strict;
 use Const::Fast qw(const);
 
-our $VERSION = '1.17.0';
+our $VERSION = '1.17.1';
 
 1;


### PR DESCRIPTION
For sanity check only

Trivial review, using libdeflate compiled htslib for caveman requires only updating the base container:

```
ubuntu@6d64a17d4fa8:~$ ldd $(which caveman)
...
	libdeflate.so.0 => /opt/wtsi-cgp/lib/libdeflate.so.0 (0x00007fed20947000)
...
```

Internal CI shows following CPU time differences:

| Data type | 1.17.0 (s) | 1.17.1 (s) | diff (s) | % of original |
|----|----|----|----|----|
| Amplicon | 3272 | 3043 | -229 | 93.00% |
| Targeted | 13911 | 13777 | -134 | 99.04% |
| WXS | 145279 | 118187 | -27092 | 81.35% |
| WGS | 2186185 | 2122906 | -63279 | 97.11% |

Improvement is using formular `new/old*100%`, where the result shows the percentage of the original time it now takes.